### PR TITLE
When touched() is called leave early

### DIFF
--- a/XPT2046_Touchscreen.cpp
+++ b/XPT2046_Touchscreen.cpp
@@ -45,19 +45,19 @@ bool XPT2046_Touchscreen::begin()
 
 TS_Point XPT2046_Touchscreen::getPoint()
 {
-	update();
+	update( true );
 	return TS_Point(xraw, yraw, zraw);
 }
 
 bool XPT2046_Touchscreen::touched()
 {
-	update();
+	update( false );
 	return (zraw >= Z_THRESHOLD);
 }
 
 void XPT2046_Touchscreen::readData(uint16_t *x, uint16_t *y, uint8_t *z)
 {
-	update();
+	update( true );
 	*x = xraw;
 	*y = yraw;
 	*z = zraw;
@@ -85,7 +85,7 @@ static int16_t besttwoavg( int16_t x , int16_t y , int16_t z ) {
 // TODO: perhaps a future version should offer an option for more oversampling,
 //       with the RANSAC algorithm https://en.wikipedia.org/wiki/RANSAC
 
-void XPT2046_Touchscreen::update()
+void XPT2046_Touchscreen::update( boolean getpoint )
 {
 	int16_t data[6];
 
@@ -98,7 +98,7 @@ void XPT2046_Touchscreen::update()
 	int z = z1 + 4095;
 	int16_t z2 = SPI.transfer16(0x91 /* X */) >> 3;
 	z -= z2;
-	if (z >= Z_THRESHOLD) {
+	if (z >= Z_THRESHOLD && getpoint) {
 		SPI.transfer16(0x91 /* X */);  // dummy X measure, 1st is always noisy
 		data[0] = SPI.transfer16(0xD1 /* Y */) >> 3;
 		data[1] = SPI.transfer16(0x91 /* X */) >> 3; // make 3 x-y measurements
@@ -118,7 +118,8 @@ void XPT2046_Touchscreen::update()
 		return;
 	}
 	zraw = z;
-	
+	if (!getpoint)
+		return;
 	// Average pair with least distance between each measured x then y
 	//Serial.printf("    z1=%d,z2=%d  ", z1, z2);
 	//Serial.printf("p=%d,  %d,%d  %d,%d  %d,%d", zraw,

--- a/XPT2046_Touchscreen.h
+++ b/XPT2046_Touchscreen.h
@@ -50,7 +50,7 @@ public:
 	uint8_t bufferSize() { return 1; }
 
 private:
-	void update();
+	void update(boolean getpoint);
 	uint8_t csPin;
 	int16_t xraw, yraw, zraw;
 	uint32_t msraw;


### PR DESCRIPTION
When only called to test touch() that can leave after 5 SPI words.
Existing code reads all 10 words then does the x,y Point math and does
not store or return the calculated value.

This uses the early exit path set up in prior pull.  call to update takes a boolean to differentiate early exit or point return.  Does not update msraw so when touch detected it can re-enter for getPoint or readData